### PR TITLE
Add simple login dialog to Launcher (JavaFX)

### DIFF
--- a/EscapeVR/src/main/java/nl/tudelft/kroket/Launcher.java
+++ b/EscapeVR/src/main/java/nl/tudelft/kroket/Launcher.java
@@ -1,5 +1,7 @@
 package nl.tudelft.kroket;
 
+import com.jme3.system.AppSettings;
+
 import javafx.application.Application;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -19,16 +21,19 @@ import javafx.stage.Stage;
 import jmevr.app.VRApplication.PRECONFIG_PARAMETER;
 import nl.tudelft.kroket.escape.EscapeVR;
 
-import com.jme3.system.AppSettings;
-
 /**
- * Entry point for VR application.
+ * Entry point for VR application. Launches a simple dialog window to
+ * prompt the user for name and remote host.
  * 
  * @author Team Kroket
  *
  */
 @SuppressWarnings("restriction")
 public class Launcher extends Application {
+
+  private static final int DIALOG_WIDTH = 500;
+  private static final int DIALOG_HEIGHT = 300;
+  private static final String DIALOG_TITLE = "Escaparade";
 
   private static String remoteHost = "127.0.0.1";
   private static String playerName = "VR-USER";
@@ -91,7 +96,9 @@ public class Launcher extends Application {
   @Override
   public void start(Stage primaryStage) {
 
-    primaryStage.setTitle("Escaparade");
+    primaryStage.setWidth(DIALOG_WIDTH);
+    primaryStage.setHeight(DIALOG_HEIGHT);
+    primaryStage.setTitle(DIALOG_TITLE);
     primaryStage.requestFocus();
 
     GridPane grid = new GridPane();
@@ -122,19 +129,23 @@ public class Launcher extends Application {
     hbBtn.getChildren().add(btn);
     grid.add(hbBtn, 1, 4);
 
-    final Text actiontarget = new Text();
-    grid.add(actiontarget, 1, 6);
+    final Text warningText = new Text();
+    grid.add(warningText, 1, 6);
 
     btn.setOnAction(new EventHandler<ActionEvent>() {
 
       @Override
       public void handle(ActionEvent e) {
 
-        remoteHost = remoteField.getText();
-        playerName = userTextField.getText();
+        if (remoteField.getText().isEmpty()) {
+          warningText.setText("Remote host field cannot be blank!");
+          warningText.setFill(Color.DARKRED);
+        } else {
+          remoteHost = remoteField.getText();
+          playerName = userTextField.getText();
+          primaryStage.close();
+        }
 
-        actiontarget.setFill(Color.FIREBRICK);
-        primaryStage.close();
       }
     });
 

--- a/EscapeVR/src/main/java/nl/tudelft/kroket/Launcher.java
+++ b/EscapeVR/src/main/java/nl/tudelft/kroket/Launcher.java
@@ -1,9 +1,25 @@
 package nl.tudelft.kroket;
 
-import com.jme3.system.AppSettings;
+import javafx.application.Application;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
 import jmevr.app.VRApplication.PRECONFIG_PARAMETER;
 import nl.tudelft.kroket.escape.EscapeVR;
 
+import com.jme3.system.AppSettings;
 
 /**
  * Entry point for VR application.
@@ -11,9 +27,13 @@ import nl.tudelft.kroket.escape.EscapeVR;
  * @author Team Kroket
  *
  */
-public class Launcher {
+@SuppressWarnings("restriction")
+public class Launcher extends Application {
 
-  static EscapeVR mainApplication;
+  private static String remoteHost = "127.0.0.1";
+  private static String playerName = "VR-USER";
+
+  private static EscapeVR mainApplication;
 
   /**
    * The main method.
@@ -23,18 +43,19 @@ public class Launcher {
    */
   public static void main(String[] args) {
 
-    String remoteHost = "127.0.0.1";
-
     // allow remote address to be set using commandline arguments
     // (for now)
     if (args.length > 1 && !args[0].isEmpty()) {
       remoteHost = args[0];
     }
 
+    launch(args);
+
     mainApplication = new EscapeVR();
-    
+
     // set the hostname/ip address of the remote machine
     mainApplication.setRemoteHost(remoteHost);
+    mainApplication.setPlayerName(playerName);
 
     // create AppSettings object to enable joysticks/gamepads
     // and set the title
@@ -48,9 +69,9 @@ public class Launcher {
 
     // throw settings at the application
     mainApplication.setSettings(settings);
-    
+
     mainApplication.preconfigureVRApp(PRECONFIG_PARAMETER.USE_CUSTOM_DISTORTION, false);
-    
+
     // enable the mirror window to be used, this will show whatever is shown in the
     // VR goggles
     mainApplication.preconfigureVRApp(PRECONFIG_PARAMETER.ENABLE_MIRROR_WINDOW, true);
@@ -65,6 +86,61 @@ public class Launcher {
     // finally, start the application
     mainApplication.start();
 
+  }
+
+  @Override
+  public void start(Stage primaryStage) {
+
+    primaryStage.setTitle("Escaparade");
+    primaryStage.requestFocus();
+
+    GridPane grid = new GridPane();
+    grid.setAlignment(Pos.CENTER);
+    grid.setHgap(10);
+    grid.setVgap(10);
+    grid.setPadding(new Insets(25, 25, 25, 25));
+
+    Text sceneTitle = new Text("Welcome");
+    sceneTitle.setFont(Font.font("Tahoma", FontWeight.NORMAL, 20));
+    grid.add(sceneTitle, 0, 0, 2, 1);
+
+    Label lblUserName = new Label("Username:");
+    grid.add(lblUserName, 0, 1);
+
+    TextField userTextField = new TextField();
+    grid.add(userTextField, 1, 1);
+
+    Label lblRemoteHost = new Label("Remote host:");
+    grid.add(lblRemoteHost, 0, 2);
+
+    TextField remoteField = new TextField();
+    grid.add(remoteField, 1, 2);
+
+    Button btn = new Button("Let's play!");
+    HBox hbBtn = new HBox(10);
+    hbBtn.setAlignment(Pos.BOTTOM_RIGHT);
+    hbBtn.getChildren().add(btn);
+    grid.add(hbBtn, 1, 4);
+
+    final Text actiontarget = new Text();
+    grid.add(actiontarget, 1, 6);
+
+    btn.setOnAction(new EventHandler<ActionEvent>() {
+
+      @Override
+      public void handle(ActionEvent e) {
+
+        remoteHost = remoteField.getText();
+        playerName = userTextField.getText();
+
+        actiontarget.setFill(Color.FIREBRICK);
+        primaryStage.close();
+      }
+    });
+
+    Scene scene = new Scene(grid, 300, 275);
+    primaryStage.setScene(scene);
+    primaryStage.show();
   }
 
 }

--- a/EscapeVR/src/main/java/nl/tudelft/kroket/Launcher.java
+++ b/EscapeVR/src/main/java/nl/tudelft/kroket/Launcher.java
@@ -1,7 +1,5 @@
 package nl.tudelft.kroket;
 
-import com.jme3.system.AppSettings;
-
 import javafx.application.Application;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -13,13 +11,14 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
-import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
 import jmevr.app.VRApplication.PRECONFIG_PARAMETER;
 import nl.tudelft.kroket.escape.EscapeVR;
+
+import com.jme3.system.AppSettings;
 
 /**
  * Entry point for VR application. Launches a simple dialog window to prompt the user for name and
@@ -129,31 +128,23 @@ public class Launcher extends Application {
     hbBtn.getChildren().add(btn);
     grid.add(hbBtn, 1, 4);
 
-    final Text warningText = new Text();
-    grid.add(warningText, 1, 6);
-
     btn.setOnAction(new EventHandler<ActionEvent>() {
 
       @Override
       public void handle(ActionEvent e) {
 
-        if (remoteField.getText().isEmpty()) {
-          warningText.setText("Remote host field cannot be blank!");
-          warningText.setFill(Color.DARKRED);
-        } else {
-
+        if (!remoteField.getText().isEmpty()) {
           remoteHost = remoteField.getText();
-
-          if (!userTextField.getText().isEmpty()) {
-            playerName = userTextField.getText();
-          }
-          primaryStage.close();
         }
-
+        if (!userTextField.getText().isEmpty()) {
+          playerName = userTextField.getText();
+        }
+        primaryStage.close();
       }
+
     });
 
-    Scene scene = new Scene(grid, 300, 275);
+    Scene scene = new Scene(grid, DIALOG_WIDTH, DIALOG_HEIGHT);
     primaryStage.setScene(scene);
     primaryStage.show();
   }

--- a/EscapeVR/src/main/java/nl/tudelft/kroket/Launcher.java
+++ b/EscapeVR/src/main/java/nl/tudelft/kroket/Launcher.java
@@ -22,8 +22,8 @@ import jmevr.app.VRApplication.PRECONFIG_PARAMETER;
 import nl.tudelft.kroket.escape.EscapeVR;
 
 /**
- * Entry point for VR application. Launches a simple dialog window to
- * prompt the user for name and remote host.
+ * Entry point for VR application. Launches a simple dialog window to prompt the user for name and
+ * remote host.
  * 
  * @author Team Kroket
  *
@@ -35,7 +35,7 @@ public class Launcher extends Application {
   private static final int DIALOG_HEIGHT = 300;
   private static final String DIALOG_TITLE = "Escaparade";
 
-  private static String remoteHost = "127.0.0.1";
+  private static String remoteHost = "localhost";
   private static String playerName = "VR-USER";
 
   private static EscapeVR mainApplication;
@@ -141,8 +141,12 @@ public class Launcher extends Application {
           warningText.setText("Remote host field cannot be blank!");
           warningText.setFill(Color.DARKRED);
         } else {
+
           remoteHost = remoteField.getText();
-          playerName = userTextField.getText();
+
+          if (!userTextField.getText().isEmpty()) {
+            playerName = userTextField.getText();
+          }
           primaryStage.close();
         }
 

--- a/EscapeVR/src/main/java/nl/tudelft/kroket/escape/EscapeVR.java
+++ b/EscapeVR/src/main/java/nl/tudelft/kroket/escape/EscapeVR.java
@@ -72,6 +72,7 @@ public class EscapeVR extends VRApplication implements EventListener {
 
   private String remoteHost;
   private int remotePort;
+  private String playerName = "VR-USER";
 
   private StateManager stateManager;
   private EventManager eventManager;
@@ -82,7 +83,7 @@ public class EscapeVR extends VRApplication implements EventListener {
   private HeadUpDisplay hud;
 
   private MinigameManager mgManager;
-  
+
   /** Thread reference used for the TCP connection. */
   private ClientThread clientThread;
 
@@ -90,8 +91,8 @@ public class EscapeVR extends VRApplication implements EventListener {
   private GameState initialState = LobbyState.getInstance();
 
   /** List of all rigid objects. */
-  private List<String> rigidObjects = new ArrayList<String>(
-      Arrays.asList("safe-objnode", "knight1-geom-0", "knight2-geom-0", "Desk-objnode"));
+  private List<String> rigidObjects = new ArrayList<String>(Arrays.asList("safe-objnode",
+      "knight1-geom-0", "knight2-geom-0", "Desk-objnode"));
 
   // private CollisionHandler collisionHandler;
   private MovementHandler movementHandler;
@@ -143,6 +144,7 @@ public class EscapeVR extends VRApplication implements EventListener {
   private void initNetworkClient() {
     clientThread = new ClientThread(this, hud);
     clientThread.setRemote(remoteHost, PORTNUM);
+    clientThread.setPlayerName(playerName);
     clientThread.start();
   }
 
@@ -183,8 +185,7 @@ public class EscapeVR extends VRApplication implements EventListener {
     // do not use magic VR mouse cusor (same usage as non-VR mouse cursor)
     getInputManager().setCursorVisible(true);
     // observer.setModelBound(bound);
-    
-    
+
     initHeadUpDisplay();
     initSceneManager();
     initAudioManager();
@@ -201,8 +202,8 @@ public class EscapeVR extends VRApplication implements EventListener {
     inputHandler.registerMappings(movementHandler, "forward", "back");
     inputHandler.registerMappings(eventManager, "Button A", "Button B", "Button X", "Button Y");
 
-    inputHandler.registerListener(
-        new CollisionHandler(observer, sceneManager.getScene("escape").getBoundaries()));
+    inputHandler.registerListener(new CollisionHandler(observer, sceneManager.getScene("escape")
+        .getBoundaries()));
 
     eventManager.addListener(this);
 
@@ -254,7 +255,7 @@ public class EscapeVR extends VRApplication implements EventListener {
       if (object.getName().equals("observer")) {
         continue;
       }
-      
+
       // only process objects that extend either Geomtery or Node
       if (object instanceof Geometry || object instanceof Node) {
 
@@ -262,7 +263,7 @@ public class EscapeVR extends VRApplication implements EventListener {
         eventManager.registerObjectInteractionTrigger(object.getName(), 4f);
       }
     }
-    
+
     // register all rigid objects with the movementhandler
     // the movementhandler will force the observer
     // to stay away from these objects
@@ -303,60 +304,60 @@ public class EscapeVR extends VRApplication implements EventListener {
     if (command.containsKey("command")) {
 
       switch (command.get("command")) {
-        case "START":
-          registerObjects();
-          setGameState(PlayingState.getInstance());
-          hud.setCenterText("");
-          break;
-          
-        //Messages received from the mobile player
-        case "INITVR":
-          if (command.containsKey("param_0")) {
-            String action = command.get("param_0");
-  
-            // End minigames, which are ended by the mobile player
-            if (action.equals("doneA") || action.equals("doneB")) {
-              if (mgManager.getCurrent() != null) {
-                mgManager.endGame();
-                registerObjects();
-              }
-  
-              // Start minigames
-            } else if (action.equals("startC")) {
-              mgManager.launchGame(ColorSequenceMinigame.getInstance());
-              if (mgManager.getCurrent() instanceof ColorSequenceMinigame) {
-                ((ColorSequenceMinigame) mgManager.getCurrent())
-                    .parseColors(CommandParser.parseParams(line));
-              }
-//            } else if (action.equals("startD")) {
-//              mgManager.launchGame(GyroscopeMinigame.getInstance());
+      case "START":
+        registerObjects();
+        setGameState(PlayingState.getInstance());
+        hud.setCenterText("");
+        break;
+
+      // Messages received from the mobile player
+      case "INITVR":
+        if (command.containsKey("param_0")) {
+          String action = command.get("param_0");
+
+          // End minigames, which are ended by the mobile player
+          if (action.equals("doneA") || action.equals("doneB")) {
+            if (mgManager.getCurrent() != null) {
+              mgManager.endGame();
+              registerObjects();
+            }
+
+            // Start minigames
+          } else if (action.equals("startC")) {
+            mgManager.launchGame(ColorSequenceMinigame.getInstance());
+            if (mgManager.getCurrent() instanceof ColorSequenceMinigame) {
+              ((ColorSequenceMinigame) mgManager.getCurrent()).parseColors(CommandParser
+                  .parseParams(line));
+            }
+            // } else if (action.equals("startD")) {
+            // mgManager.launchGame(GyroscopeMinigame.getInstance());
+          }
+        }
+        break;
+
+      // Messages sent by the VR client itself, which it gets back as verification.
+      case "INITM":
+        if (command.containsKey("param_0")) {
+          String action = command.get("param_0");
+
+          // Verifiation from server that minigames should start
+          if (action.equals("startA")) {
+            mgManager.launchGame(PictureCodeMinigame.getInstance());
+          } else if (action.equals("startB")) {
+            mgManager.launchGame(TapMinigame.getInstance());
+          }
+
+          // End minigames, which are ended by the mobile player
+          if (action.equals("doneC")) {
+            if (mgManager.getCurrent() != null) {
+              mgManager.endGame();
             }
           }
-          break;
-          
-        // Messages sent by the VR client itself, which it gets back as verification.
-        case "INITM":
-          if (command.containsKey("param_0")) {
-            String action = command.get("param_0");
-            
-            // Verifiation from server that minigames should start
-            if (action.equals("startA")) {
-              mgManager.launchGame(PictureCodeMinigame.getInstance());
-            } else if (action.equals("startB")) {
-              mgManager.launchGame(TapMinigame.getInstance());
-            }
-            
-            // End minigames, which are ended by the mobile player
-            if (action.equals("doneC")) {
-              if (mgManager.getCurrent() != null) {
-                mgManager.endGame();
-              }
-            }
-          }
-          break;
-          
-        default:
-          hud.setCenterText(line, 20);
+        }
+        break;
+
+      default:
+        hud.setCenterText(line, 20);
       }
     }
   }
@@ -368,7 +369,7 @@ public class EscapeVR extends VRApplication implements EventListener {
    *          the input received from the socket.
    */
   public void receiveLoop(String message) {
-    
+
     log.debug(className, "Message received: " + message);
 
     remoteInput(message);
@@ -376,7 +377,7 @@ public class EscapeVR extends VRApplication implements EventListener {
 
   @Override
   public void handleEvent(EventObject ev) {
-    
+
     if (ev instanceof InteractionEvent) {
       InteractionEvent interactionEvent = (InteractionEvent) ev;
 
@@ -449,6 +450,11 @@ public class EscapeVR extends VRApplication implements EventListener {
    */
   public void setRemotePort(int remotePort) {
     this.remotePort = remotePort;
+  }
+
+  public void setPlayerName(String playerName) {
+    this.playerName = playerName;
+
   }
 
 }

--- a/EscapeVR/src/main/java/nl/tudelft/kroket/net/ClientThread.java
+++ b/EscapeVR/src/main/java/nl/tudelft/kroket/net/ClientThread.java
@@ -20,7 +20,7 @@ public class ClientThread extends Thread {
 
   private final int reconnInterval = 5;
 
-  private String playerName = "RIFT-USER";
+  private String playerName = "VR-USER";
 
   EscapeVR callback;
   HeadUpDisplay hud;

--- a/EscapeVR/src/main/java/nl/tudelft/kroket/net/NetworkClient.java
+++ b/EscapeVR/src/main/java/nl/tudelft/kroket/net/NetworkClient.java
@@ -142,6 +142,7 @@ public class NetworkClient {
 
     try {
       dataOutputStream.writeBytes(message);
+      dataOutputStream.flush();
     } catch (IOException e) {
       setConnected(false);
     }


### PR DESCRIPTION
Added a very simple login dialog window to prompt the user for name and remote host.

This uses JavaFX. Java8 was a requirement for this application, so using JavaFX shouldn't be a problem. I considered using the internal dialogs but those have only been available since 8u40. 

The name can be left blank: it'll use VR-USER by default. 
The remote host cannot be left blank. Perhaps we could make it use 'localhost' otherwise?

Other than checking for an empty field, there is no input sanitation/validation in place. The host field can be any string, since I also want it to process hostnames (not just IP addresses).

Please review. 
